### PR TITLE
Boot.php umstrukturiert

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -36,8 +36,8 @@ rex_view::addCssFile($addon->getAssetsUrl('bqc.css'));
 
 /**
  * automatisch erzeugten Titel für die eigene Navigationsgruppe "base_addon"
- * entfernen durch "Bereitstellen" eines leeren Textes. CSS sorgt dann für die Optik.
- * TODO: könnte man auch in einer .lang-Datei unterbringen.
+ * entfernen durch "Bereitstellen" eines leeren Textes. CSS sorgt dann für die
+ * Optik. (klappt nur so, nicht per .lang-Datei)
  *
  * STAN: RexStan meckert hier an, dass der Text eigentlich nicht leer sein darf.
  * @phpstan-ignore-next-line
@@ -117,7 +117,6 @@ if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
 }
 
 /**
- * JS einbinden und eine identifizierende CSS-Klasse hinzufügen
- * TODO: prüfen, ob man die Klasse via index.php setzt oder auf dem <body>. => OUTPUT_FILTER raus.
+ * JS für die BE-Seite des Addons einbinden
  */
 rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));

--- a/boot.php
+++ b/boot.php
@@ -15,13 +15,13 @@ if (rex::isFrontend()) {
 
 /**
  * CSS benötigen wir so oder so.
- * 
+ *
  * Kleine Vorarbeit on Demand: SCSS neu kompilieren
  * Auslöser ist die Property 'compile' auf «true».
  */
-rex_extension::register('PACKAGES_INCLUDED', function () {
+rex_extension::register('PACKAGES_INCLUDED', static function () {
     $addon = rex_addon::get('base_quality_check');
-    if (true === $addon->getProperty('compile',false)) {
+    if (true === $addon->getProperty('compile', false)) {
         $compiler = new rex_scss_compiler();
         $scss_files = rex_extension::registerPoint(new rex_extension_point('BE_STYLE_SCSS_FILES', [$addon->getPath('scss/bqc.scss')]));
         $compiler->setScssFile($scss_files);
@@ -38,7 +38,7 @@ rex_view::addCssFile($addon->getAssetsUrl('bqc.css'));
  * automatisch erzeugten Titel für die eigene Navigationsgruppe "base_addon"
  * entfernen durch "Bereitstellen" eines leeren Textes. CSS sorgt dann für die Optik.
  * TODO: könnte man auch in einer .lang-Datei unterbringen.
- * 
+ *
  * STAN: RexStan meckert hier an, dass der Text eigentlich nicht leer sein darf.
  * @phpstan-ignore-next-line
  */
@@ -66,7 +66,6 @@ rex_yform_manager_dataset::setModelClass(
  * 2) Menüpunkt im Hauptmenu erweitern und stylen (Füllstandsanzeige).
  */
 rex_extension::register('PAGES_PREPARED', static function ($ep) {
-
     /**
      * Ggf. in der URL stehende Parameter auswerten und verarbeiten
      * func=checktask bzw. func=unchecktask   "check" auf 1 oder 0 setzen
@@ -119,6 +118,6 @@ if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
 
 /**
  * JS einbinden und eine identifizierende CSS-Klasse hinzufügen
- * TODO: prüfen, ob man die Klasse via index.php setzt oder auf dem <body>. => OUTPUT_FILTER raus
+ * TODO: prüfen, ob man die Klasse via index.php setzt oder auf dem <body>. => OUTPUT_FILTER raus.
  */
 rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));

--- a/boot.php
+++ b/boot.php
@@ -140,8 +140,8 @@ if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
 }
 
 /**
- * JS einbinden.
- * 
+ * JS einbinden und eine identifizierende CSS-Klasse hinzufügen
+ * TODO: prüfen, ob man die Klasse via index.php setzt oder auf dem <body>. => OUTPUT_FILTER raus
  */
 rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));
 

--- a/boot.php
+++ b/boot.php
@@ -8,15 +8,8 @@ $addon = rex_addon::get('base_quality_check');
 
 /**
  * Alles nur sinnvoll im BE. Wenn FE direkt abbrechen.
- * Alles Weitere ist inhaltsbezogen und unterbleibt im SafeMode
- * ->Addon-Seiten komplett ausblenden
- * TODO: sind noch andere (BE-)Situationen ein Auschlußgrund? Console?
  */
 if (rex::isFrontend()) {
-    return;
-}
-if (rex::isSafeMode()) {
-    $addon->removeProperty('page');
     return;
 }
 
@@ -50,21 +43,6 @@ rex_view::addCssFile($addon->getAssetsUrl('bqc.css'));
  * @phpstan-ignore-next-line
  */
 rex_i18n::addMsg('navigation_base_addon', '');
-
-/**
- * Ohne YForm geht es nicht. Wenn YForm nicht aktiv ist, wird das Addon
- * ausgeblendet und ein Logeintrag geschrieben
- * TODO: einfach eine Exception werfen weil das Addon eh nur für Admins zugänglich und es zu 99.9% ein Entwicklerfehler ist.
- */
-if (!rex_addon::get('yform')->isAvailable()) {
-    $msg = sprintf(
-        'Addon «%s» benötige das Addon «YForm»! «YForm» ist momentan nicht verfügbar. Abbruch.',
-        $addon->getName(),
-    );
-    rex_logger::factory()->error($msg);
-    $addon->removeProperty('page');
-    return;
-}
 
 /**
  * ModelClasses zuweisen.
@@ -144,7 +122,3 @@ if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
  * TODO: prüfen, ob man die Klasse via index.php setzt oder auf dem <body>. => OUTPUT_FILTER raus
  */
 rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));
-
-rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
-    $ep->setSubject(str_replace('class="rex-page-main', 'class="bqc-addon rex-page-main-inner', $ep->getSubject()));
-});

--- a/boot.php
+++ b/boot.php
@@ -6,29 +6,36 @@ use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckSubGroup;
 
 $addon = rex_addon::get('base_quality_check');
 
-if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
-    rex_yform_manager_dataset::setModelClass(
-        'rex_base_quality_check',
-        BaseQualityCheck::class,
-    );
-    rex_yform_manager_dataset::setModelClass(
-        'rex_base_quality_check_group',
-        BaseQualityCheckGroup::class,
-    );
-    rex_yform_manager_dataset::setModelClass(
-        'rex_base_quality_check_sub_group',
-        BaseQualityCheckSubGroup::class,
-    );
+/**
+ * Alles nur sinnvoll im BE. Wenn FE direkt abbrechen.
+ * Alles Weitere ist inhaltsbezogen und unterbleibt im SafeMode
+ * ->Addon-Seiten komplett ausblenden
+ * TODO: sind noch andere (BE-)Situationen ein Auschlußgrund? Console?
+ */
+if (rex::isFrontend()) {
+    return;
+}
+if (rex::isSafeMode()) {
+    $addon->removeProperty('page');
+    return;
 }
 
+/**
+ * CSS benötigen wir so oder so.
+ * 
+ * Kleine Vorarbeit on Demand: SCSS neu kompilieren
+ * Auslöser ist die Property 'compile' auf «true».
+ */
 rex_extension::register('PACKAGES_INCLUDED', function () {
-    if (rex::getUser() && true === $this->getProperty('compile')) {
+    $addon = rex_addon::get('base_quality_check');
+    if (true === $addon->getProperty('compile',false)) {
         $compiler = new rex_scss_compiler();
-        $scss_files = rex_extension::registerPoint(new rex_extension_point('BE_STYLE_SCSS_FILES', [$this->getPath('scss/bqc.scss')]));
+        $scss_files = rex_extension::registerPoint(new rex_extension_point('BE_STYLE_SCSS_FILES', [$addon->getPath('scss/bqc.scss')]));
         $compiler->setScssFile($scss_files);
-        $compiler->setCssFile($this->getPath('assets/bqc.css'));
+        $compiler->setCssFile($addon->getPath('assets/bqc.css'));
         $compiler->compile();
-        rex_file::copy($this->getPath('assets/bqc.css'), $this->getAssetsPath('bqc.css'));
+        rex_file::copy($addon->getPath('assets/bqc.css'), $addon->getAssetsPath('bqc.css'));
+        $addon->removeProperty('compile');
     }
 });
 
@@ -36,42 +43,71 @@ rex_view::addCssFile($addon->getAssetsUrl('bqc.css'));
 
 /**
  * automatisch erzeugten Titel für die eigene Navigationsgruppe "base_addon"
- * entfernen durch bereitstellen eines leeren Textes. CSS sorgt dann für die Optik.
+ * entfernen durch "Bereitstellen" eines leeren Textes. CSS sorgt dann für die Optik.
+ * TODO: könnte man auch in einer .lang-Datei unterbringen.
+ * 
+ * STAN: RexStan meckert hier an, dass der Text eigentlich nicht leer sein darf.
+ * @phpstan-ignore-next-line
  */
 rex_i18n::addMsg('navigation_base_addon', '');
 
-
-if (isset($_GET['page']) && is_string($_GET['page']) && preg_match('/base_quality_check/', $_GET['page'])) {
-    rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));
-
-    rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
-        $ep->setSubject(str_replace('class="rex-page-main', 'class="bqc-addon rex-page-main', $ep->getSubject()));
-    });
-}
-
-$func = rex_request('func', 'string');
-$id = rex_request('id', 'int');
-
-if ('' !== $func && '' !== $id) {
-    $sql = rex_sql::factory();
-    $sql->setTable('rex_base_quality_check');
-    $sql->setWhere('id = :id', ['id' => $id]);
-    $sql->setValue('check', 'checktask' == $func ? 1 : 0);
-    $sql->update();
+/**
+ * Ohne YForm geht es nicht. Wenn YForm nicht aktiv ist, wird das Addon
+ * ausgeblendet und ein Logeintrag geschrieben
+ * TODO: einfach eine Exception werfen weil das Addon eh nur für Admins zugänglich und es zu 99.9% ein Entwicklerfehler ist.
+ */
+if (!rex_addon::get('yform')->isAvailable()) {
+    $msg = sprintf(
+        'Addon «%s» benötige das Addon «YForm»! «YForm» ist momentan nicht verfügbar. Abbruch.',
+        $addon->getName(),
+    );
+    rex_logger::factory()->error($msg);
+    $addon->removeProperty('page');
+    return;
 }
 
 /**
- * Menüpunkt im Hauptmenu mit zusätzlichem HTML-Container für den Füllstand
- * versehen und per Query den Füllstand ermitteln und eintragen.
+ * ModelClasses zuweisen.
+ */
+rex_yform_manager_dataset::setModelClass(
+    'rex_base_quality_check',
+    BaseQualityCheck::class,
+);
+rex_yform_manager_dataset::setModelClass(
+    'rex_base_quality_check_group',
+    BaseQualityCheckGroup::class,
+);
+rex_yform_manager_dataset::setModelClass(
+    'rex_base_quality_check_sub_group',
+    BaseQualityCheckSubGroup::class,
+);
+
+/**
+ * Erst nachdem alle Packages geladen sind können diese beiden Aktionen ablaufen
+ * 1) Aus dem Aufruf der Seite ggf. einen Check-Haken setzen/entfernen
+ * 2) Menüpunkt im Hauptmenu erweitern und stylen (Füllstandsanzeige).
  */
 rex_extension::register('PAGES_PREPARED', static function ($ep) {
 
-    $pages = $ep->getSubject();
-    if (!isset($pages['base_quality_check'])) {
-        return;
+    /**
+     * Ggf. in der URL stehende Parameter auswerten und verarbeiten
+     * func=checktask bzw. func=unchecktask   "check" auf 1 oder 0 setzen
+     * id=satznummer                          Satznummer in BaseQualityCheck.
+     */
+    $func = rex_request::request('func', 'string', '');
+    if ('checktask' === $func || 'unchecktask' === $func) {
+        $id = rex_request::request('id', 'int', 0);
+        $data = BaseQualityCheck::get($id);
+        if (null !== $data) {
+            $data->setCheck('checktask' === $func ? 1 : 0);
+            $data->save();
+        }
     }
 
-    // Füllstand berechnen
+    /**
+     * Füllstand berechnen und den Menütitel um die Anzeige
+     * erweitern.
+     */
     $status = BaseQualityCheck::query()
         ->resetSelect()
         ->select('id')
@@ -85,14 +121,30 @@ rex_extension::register('PAGES_PREPARED', static function ($ep) {
     $checked = $status[1] ?? 0;
     $quota = round($checked / $sum * 100, 0);
 
-    // Menüpunkt markieren
-    $page = $pages['base_quality_check'];
-    $name = $page->getTitle();
+    $page = rex_be_controller::getPageObject('base_quality_check');
     $name = sprintf(
         '%s <span class="bqc-badge %s">%d %%</span>',
-        $name,
+        $page->getTitle(),
         BqcTools::quotaClass($quota),
         $quota,
     );
     $page->setTitle($name);
+});
+
+/**
+ * Die weiteren Aktionen (im BE) sind nur notwendig, wenn die Addon-Seite selbst
+ * aufgerufen wird.
+ */
+if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
+    return;
+}
+
+/**
+ * JS einbinden.
+ * 
+ */
+rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));
+
+rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
+    $ep->setSubject(str_replace('class="rex-page-main', 'class="bqc-addon rex-page-main-inner', $ep->getSubject()));
 });

--- a/package.yml
+++ b/package.yml
@@ -28,6 +28,7 @@ page:
 requires:
   redaxo: '^5.15'
   yform: '^4.2.1'
+  yform/manager: '^4.2.1'
 
 installer_ignore:
     - .git

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: base_quality_check
-version: 1.5.0
+version: 1.6.0
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/base_quality_check
 compile: false

--- a/package.yml
+++ b/package.yml
@@ -11,11 +11,11 @@ page:
   block: base_addon  
   subpages:
     frontend:   
-      title: Frontend <div id="frontendcount"></div>
+      title: Frontend
     backend:   
-      title: Backend <div id="backendcount"></div>   
+      title: Backend   
     live:   
-      title: Live <div id="livecount"></div>            
+      title: Live          
     readme:
         title: Info
         subPath: README.md

--- a/pages/index.php
+++ b/pages/index.php
@@ -81,12 +81,17 @@ foreach($group2page as $groupId=>$groupPageName) {
 }
 
 /**
- * Seitenheader aufbauen, anschließend die Titel wieder auf den
- * Stand ohne Zähler zurücksetzen
+ * Ausgabe der Seiten: 
+ * 
+ * 1) Seitenheader aufbauen, anschließend die Titel wieder auf den
+ *    Stand ohne Zähler zurücksetzen
+ * 2) Den jeweiligen Content ausgeben
+ * 3) Alles in einen <DIV> mit einer für das CSS identifizieren Klasse einpacken
  */
+echo '<div class="bqc-addon">';
 echo rex_view::title('Base Quality Check');
 foreach( $title4reset as $name=>$groupPage) {
     $groupPage->setTitle($name);
 }
-/** */
 rex_be_controller::includeCurrentPageSubPath();
+echo '</div>';

--- a/pages/index.php
+++ b/pages/index.php
@@ -2,10 +2,10 @@
 
 /**
  * Zuerst werden aus der Datenbank die Informationen über abgehakte bzw. insg.
- * vorhandene Prüfobjekte ermittelt (gruppiert nach Gruppe und ja/nein)
- * 
+ * vorhandene Prüfobjekte ermittelt (gruppiert nach Gruppe und ja/nein).
+ *
  * Die zugehörigen Seitentitel werden um die Ergebnisse ergänzt.
- * 
+ *
  * Dann erst wird die Addon-Seite aufgebaut
  */
 
@@ -15,20 +15,20 @@ use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
 
 /**
  * Für alle Gruppen die Checks abfragen; gruppiert wird über Gruppe und Check
- * Daraus ein Status-Array erstellen: [gruppe][check] = anzahl
+ * Daraus ein Status-Array erstellen: [gruppe][check] = anzahl.
  */
 $data = BaseQualityCheck::query()
     ->resetSelect()
     ->select('id')
     ->select('group')
     ->select('check')
-    ->selectRaw('COUNT(id)','ct')
-    ->where('status',1)
+    ->selectRaw('COUNT(id)', 'ct')
+    ->where('status', 1)
     ->groupBy('group')
     ->groupBy('check')
     ->find();
 $status = [];
-foreach( $data as $item) {
+foreach ($data as $item) {
     $status[$item->getValue('group')][$item->getValue('check')] = $item->getValue('ct');
 }
 
@@ -51,22 +51,22 @@ $subPages = $page->getParent()->getSubpages();
  * unterschiedliche Farben gesetzt.
  */
 $title4reset = [];
-foreach($group2page as $groupId=>$groupPageName) {
+foreach ($group2page as $groupId => $groupPageName) {
     // Komisch! Es gibt die Seite nicht.
     // TODO: ggf. hier eine Developer-Exception werfen
-    if( !isset($subPages[$groupPageName])) {
+    if (!isset($subPages[$groupPageName])) {
         continue;
     }
     // Komisch! das ist eine Gruppe, zu der es keine Einträge gibt?
     // TODO: ggf. hier eine Developer-Exception werfen
-    if( !isset($status[$groupId])) {
+    if (!isset($status[$groupId])) {
         continue;
     }
 
     $sum = array_sum($status[$groupId]);
-    $checked = isset($status[$groupId][1]) ? $status[$groupId][1] : 0;
-    $quota = round($checked/$sum*100,0);
-    
+    $checked = $status[$groupId][1] ?? 0;
+    $quota = round($checked / $sum * 100, 0);
+
     $groupPage = $subPages[$groupPageName];
     $name = $groupPage->getTitle();
     $title4reset[$name] = $groupPage;
@@ -81,8 +81,8 @@ foreach($group2page as $groupId=>$groupPageName) {
 }
 
 /**
- * Ausgabe der Seiten: 
- * 
+ * Ausgabe der Seiten:
+ *
  * 1) Seitenheader aufbauen, anschließend die Titel wieder auf den
  *    Stand ohne Zähler zurücksetzen
  * 2) Den jeweiligen Content ausgeben
@@ -90,7 +90,7 @@ foreach($group2page as $groupId=>$groupPageName) {
  */
 echo '<div class="bqc-addon">';
 echo rex_view::title('Base Quality Check');
-foreach( $title4reset as $name=>$groupPage) {
+foreach ($title4reset as $name => $groupPage) {
     $groupPage->setTitle($name);
 }
 rex_be_controller::includeCurrentPageSubPath();


### PR DESCRIPTION
@olien: bitte nicht sofort ein neues Release machen; da kommen noch was ...

## package.yml

Da hat sich wieder was eingeschlichen, was seit PR #4 nicht mehr erforderlich ist. Ich hab es wieder gelöscht. (Sub-Seitentitel ohne Zusatz-HTML!)

## boot.php

1) Kommentare hinzugefügt
2) Reihenfolge so geändert, dass Aktionen nur ablaufen, wenn es aus dem Kontext sinnvoll ist (closes #11)
3) Abfrage auf Vorhandensein von YForm entfernt (ist durch package.yml erledigt) -> zusätzlich yform/manager als Voraussetzung eingetragen
4) Abfrage auf Nicht-im SafeMode entfernt, da Addon im SafeMode eh aus sind.
5) Alle Tabellen-Aktionen laufen über YForm, auch Speichern des Check-Wertes
6) Einbau der Klammer-Klasse `.bqc-addon` via DIV-Tag in der `index.php` vermeidet den EP OUTPUT-FILTER.
7) RexStan-Überprüfung für `boot.php` und `index.php` durchgeführt
8) Hinweise auf weitere Anpassungen bzw. Überlegungen (`TODO: ....`)

