### PR TITLE
BcqTools.php überarbeitet

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -3,6 +3,7 @@
 use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
 use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckGroup;
 use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckSubGroup;
+use FriendsOfRedaxo\BaseQualityCheck\BqcTools;
 
 $addon = rex_addon::get('base_quality_check');
 

--- a/lib/BqcTools.php
+++ b/lib/BqcTools.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace FriendsOfRedaxo\BaseQualityCheck;
+
 /**
  * Service-Klasse mit Tools
  */
@@ -16,9 +18,9 @@ class BqcTools {
             $class = 'bqc-badge-warning';
         } elseif ($quota < 75) {
             $class = 'bqc-badge-primary';
-        } elseif ($quota < 99) {
+        } elseif ($quota < 100) {
             $class = 'bqc-badge-info';
-        } elseif (100 == $quota) {
+        } else {
             $class = 'bqc-badge-success';
         }
         return $class;

--- a/lib/BqcTools.php
+++ b/lib/BqcTools.php
@@ -3,15 +3,16 @@
 namespace FriendsOfRedaxo\BaseQualityCheck;
 
 /**
- * Service-Klasse mit Tools
+ * Service-Klasse mit Tools.
  */
-class BqcTools {
-
+class BqcTools
+{
     /**
      * Übersetzt einen %-Satz (Erreichnungsgrad, Füllgrad) in CSS-Klassen
-     * zur farblichen Darstellung
+     * zur farblichen Darstellung.
      */
-    static public function quotaClass(int|float $quota) : string {
+    public static function quotaClass(int|float $quota): string
+    {
         if ($quota < 25) {
             $class = 'bqc-badge-danger';
         } elseif ($quota < 50) {

--- a/pages/index.php
+++ b/pages/index.php
@@ -10,6 +10,7 @@
  */
 
 use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
+use FriendsOfRedaxo\BaseQualityCheck\BqcTools;
 
 /** @var rex_addon $this */
 


### PR DESCRIPTION
- Den in PR #10 vegessenen Namespace für `BqcTools.php` nachgetragen und Referenzen in anderen Dateien angepasst
- `BqcTools.::quotaClass`: Bug in der Ermittlung der CSS-Klasse behoben (Danke, RexStan)
- RexStan-Überprüfung
- PhpCsFixer-Formatierung