### PR TITLE
Abfrage der Tasks als Methode der Group-Klasse

### DIFF
--- a/fragments/pagecontent.php
+++ b/fragments/pagecontent.php
@@ -5,34 +5,32 @@
 use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
 
 /**
- * Variablen für das Fragment
+ * Variablen für das Fragment.
  */
 /** @var int $group */
 $group = $this->getVar('group', 0);
 
-/** @var rex_yform_manager_collection<BaseQualityCheck>|array{} $tasklist */
-$tasklist = $this->getVar('tasklist',[]);
+/** @var rex_yform_manager_collection<BaseQualityCheck> $tasklist */
+$tasklist = $this->getVar('tasklist', []);
 
 $currentSubGroup = '';
 $rows = [];
 foreach ($tasklist as $task) {
-
     /**
      * Ermitteln, ob die Task erlefigt ist
-     * Die Zeile der Tabelle entsprechend markieren
+     * Die Zeile der Tabelle entsprechend markieren.
      */
     $isCompleted = 1 == $task->getCheck();
 
     $column = [];
-    $column[] = '<tr class="'.($isCompleted ? 'bqc-completed' : '').'">';
+    $column[] = '<tr class="' . ($isCompleted ? 'bqc-completed' : '') . '">';
 
     /**
      * Spalte 1: Name der Untergruppe mit Gruppenwechsel (nur in der ersten Zeile).
      * Also für die Folgezeilen keinen Gruppentitel mehr ausgeben.
      * Es wird unterstellt, dass es die SubGroup gibt!
-     * 
      */
-    $subGroup = $task->getSubgroup()->getSubgroup();
+    $subGroup = $task->getValue('subgroupname');
     if ($currentSubGroup !== $subGroup) {
         $currentSubGroup = $subGroup;
         $column[] = '<td>' . $currentSubGroup . '</td>';
@@ -45,7 +43,7 @@ foreach ($tasklist as $task) {
      */
     $action = $isCompleted ? 'unchecktask' : 'checktask';
     $label = $isCompleted ? 'Als unerledigt markieren' : 'Als erledigt markieren';
-    $link = '<a class="tasklink" href="' . rex_url::currentBackendPage(['func' => $action, 'id' => $task->getId()]) . '" title="'.$label.'">
+    $link = '<a class="tasklink" href="' . rex_url::currentBackendPage(['func' => $action, 'id' => $task->getId()]) . '" title="' . $label . '">
                 <svg  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round" >
                         <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 3m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
                         <path class="checkmark" d="M9 12l2 2l4 -4" />
@@ -97,7 +95,6 @@ foreach ($tasklist as $task) {
     $column[] = '</tr>';
 
     $rows[] = implode('', $column);
-
 }
 
 ?>

--- a/lib/BaseQualityCheck.php
+++ b/lib/BaseQualityCheck.php
@@ -18,9 +18,9 @@ class BaseQualityCheck extends rex_yform_manager_dataset
     {
         $yform = parent::getForm();
 
-        if(!rex_addon::get('cke5')->isAvailable()) {
-            foreach( $yform->objparams['form_elements'] as $k=>&$e) {
-                if($e[0] === 'textarea' && str_contains($e[5],'cke5-editor')) {
+        if (!rex_addon::get('cke5')->isAvailable()) {
+            foreach ($yform->objparams['form_elements'] as $k => &$e) {
+                if ('textarea' === $e[0] && str_contains($e[5], 'cke5-editor')) {
                     $e[5] = '';
                 }
             }

--- a/pages/backend.php
+++ b/pages/backend.php
@@ -1,23 +1,16 @@
 <?php
 
-use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
+use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckGroup;
 
 $group = 2;
 $page = rex_be_controller::getCurrentPageObject();
 $pagetitle = $page->getTitle();
 
-$tasklist = BaseQualityCheck::query()
-    ->where('status', 1, '=')
-    ->where('group', $group, '=')
-    ->orderBy('prio', 'ASC')
-    ->find();
-
 $page_fragment = new rex_fragment();
 $page_fragment->setVar('group', $group, false);
-$page_fragment->setVar('tasklist', $tasklist);
+$page_fragment->setVar('tasklist', BaseQualityCheckGroup::fetchByGroup($group));
 
-$fragment = new \rex_fragment();
+$fragment = new rex_fragment();
 $fragment->setVar('title', $pagetitle, false);
 $fragment->setVar('body', $page_fragment->parse('pagecontent.php'), false);
 echo $fragment->parse('core/page/section.php');
-

--- a/pages/frontend.php
+++ b/pages/frontend.php
@@ -1,20 +1,14 @@
 <?php
 
-use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
+use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckGroup;
 
 $group = 1;
 $page = rex_be_controller::getCurrentPageObject();
 $pagetitle = $page->getTitle();
 
-$tasklist = BaseQualityCheck::query()
-    ->where('status', 1, '=')
-    ->where('group', $group, '=')
-    ->orderBy('prio', 'ASC')
-    ->find();
-
 $page_fragment = new rex_fragment();
 $page_fragment->setVar('group', $group, false);
-$page_fragment->setVar('tasklist', $tasklist);
+$page_fragment->setVar('tasklist', BaseQualityCheckGroup::fetchByGroup($group));
 
 $fragment = new rex_fragment();
 $fragment->setVar('title', $pagetitle, false);

--- a/pages/live.php
+++ b/pages/live.php
@@ -1,23 +1,16 @@
 <?php
 
-use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheck;
+use FriendsOfRedaxo\BaseQualityCheck\BaseQualityCheckGroup;
 
 $group = 3;
 $page = rex_be_controller::getCurrentPageObject();
 $pagetitle = $page->getTitle();
 
-$tasklist = BaseQualityCheck::query()
-    ->where('status', 1, '=')
-    ->where('group', $group, '=')
-    ->orderBy('prio', 'ASC')
-    ->find();
-
 $page_fragment = new rex_fragment();
 $page_fragment->setVar('group', $group, false);
-$page_fragment->setVar('tasklist', $tasklist);
+$page_fragment->setVar('tasklist', BaseQualityCheckGroup::fetchByGroup($group));
 
-$fragment = new \rex_fragment();
+$fragment = new rex_fragment();
 $fragment->setVar('title', $pagetitle, false);
 $fragment->setVar('body', $page_fragment->parse('pagecontent.php'), false);
 echo $fragment->parse('core/page/section.php');
-


### PR DESCRIPTION
Den Code etwas umstrukturiert ...

In `BaseQualityCheckGroup` gibt es nun eine Methode `BaseQualityCheckGroup::taskList`, die die zur Gruppe gehörenden Checks/Tasks als Collection bereitstellt. Die Unterschiede zur`getRelatedCollection` sind:

- Sortiert nach Prio
- gefiltert nach Status
- subgroup-ID aufgelöst in den Namen (`subgroupname` als Value) über Join.

Eine statische Methode erlaubt Auswahl der Group und Lieferung der Liste in einem Aufruf.

Entsprechend sind die drei Check-Pages etwas umgebaut und abgespeckt, um diese Methoden zu nutzen. Das Fragment nutzt nun `$task->getValue('subgroupname')` stattt $task->getSubgroup()->getSubgroup()'`, was die Einzelabfragen der Subgroup-Datensätze einspart (ist ja schon beim Anlegen der Liste via Join in nur einer Abfrage passiert.