### PR TITLE
Bugfix zu #23 und #24

### DIFF
--- a/lib/BaseQualityCheckGroup.php
+++ b/lib/BaseQualityCheckGroup.php
@@ -47,7 +47,7 @@ class BaseQualityCheckGroup extends rex_yform_manager_dataset
      */
     public function taskList(bool $activeOnly = true): rex_yform_manager_collection
     {
-        $query = self::query();
+        $query = BaseQualityCheck::query();
         $alias = $query->getTableAlias();
 
         $query

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,12 +18,6 @@ try {
         \rex_sql_table::get( $table )->drop();
     }
 
-    // Cronjobs löschen
-    $sql = \rex_sql::factory();
-    $sql->setTable( \rex::getTable( 'cronjob') );
-    $sql->setWhere( 'type=:type', [':type'=>'FriendsOfRedaxo\\Geolocation\\Cronjob'] );
-    $sql->delete();
-
 } catch (\RuntimeException $e) {
 
     $this->setProperty('installmsg', $e->getMessage() );


### PR DESCRIPTION
In #22 war ein kleiner Fehler reingekommen. Details in #23. Der PR behebt das Problem in `BaseQualityCheckGroup::tasklist()`.

closes #23

In der `uninstall.php` findet sich coch Code aus Geolocation (Copy-Fehler). Entfernt.

closes #24 