### PR TITLE
.form-control ergänzt; Umstellung auf rex_loader-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@ Base Quality Check - Changelog
 ================================================================================
 
 
-## Version 1.8.0 06.08.2024
+## Version 1.8.0 14.08.2024
 
 Datentypen in der Datenbank optimert (`int` statt `text`); Versionen vor 1.8.0 werden
 automatisch aktualisiert.
 
 Fehlende Klasse `form-control` im YForm-Formular ergänzt.
+
+Umstellung auf rex_loader-API und Redaxo-Mindestversion 5.17.0 (passend zu YForm)
 
 ## Version 1.7.0 06.08.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Base Quality Check - Changelog
 Datentypen in der Datenbank optimert (`int` statt `text`); Versionen vor 1.8.0 werden
 automatisch aktualisiert.
 
+Fehlende Klasse `form-control` im YForm-Formular ergänzt.
+
 ## Version 1.7.0 06.08.2024
 
 Source-Code in der Detailbeschreibung einzelner Checks wird nun sprachspezifisch farbig

--- a/assets/bqc.js
+++ b/assets/bqc.js
@@ -1,8 +1,0 @@
-$(document).on('rex:ready', function(event, container) {
-
-    $('.tasklink').click(function(e) {
-        $('.rex-ajax-loader').addClass('rex-visible');
-
-    });
-
-});

--- a/boot.php
+++ b/boot.php
@@ -125,9 +125,7 @@ if (rex_be_controller::getCurrentPagePart(1) !== $addon->getName()) {
 
 /**
  * JS für die BE-Seite des Addons einbinden
- * - allgemeins Zeug für die Addon-Seite
  * - Code-Blöcke farbig anzeigen mit PrismJS
  */
 rex_view::addJsFile($addon->getAssetsUrl('prism.min.js'));
 rex_view::addCssFile($addon->getAssetsUrl('prism.min.css'));
-rex_view::addJsFile($addon->getAssetsUrl('bqc.js'));

--- a/fragments/pagecontent.php
+++ b/fragments/pagecontent.php
@@ -52,7 +52,7 @@ foreach ($tasklist as $task) {
      */
     $action = $isCompleted ? 'unchecktask' : 'checktask';
     $label = $isCompleted ? 'Als unerledigt markieren' : 'Als erledigt markieren';
-    $link = '<a class="tasklink" href="' . rex_url::currentBackendPage(['func' => $action, 'id' => $task->getId()]) . '" title="' . $label . '">
+    $link = '<a class="tasklink" onclick="rex_loader.show()" href="' . rex_url::currentBackendPage(['func' => $action, 'id' => $task->getId()]) . '" title="' . $label . '">
                 <svg  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round" >
                         <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 3m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
                         <path class="checkmark" d="M9 12l2 2l4 -4" />

--- a/install/tableset.json
+++ b/install/tableset.json
@@ -115,7 +115,7 @@
                 "not_required": "",
                 "default": "",
                 "no_db": "0",
-                "attributes": "{\"class\":\"cke5-editor\",\"data-profile\":\"bqc\",\"data-lang\":\"de\"}",
+                "attributes": "{\"class\":\"form-control cke5-editor\",\"data-profile\":\"bqc\",\"data-lang\":\"de\"}",
                 "notice": ""
             },
             {
@@ -147,7 +147,7 @@
                 "not_required": "",
                 "default": "",
                 "no_db": "0",
-                "attributes": "{\"class\":\"cke5-editor\",\"data-profile\":\"bqc\",\"data-lang\":\"de\"}",
+                "attributes": "{\"class\":\"form-control cke5-editor\",\"data-profile\":\"bqc\",\"data-lang\":\"de\"}",
                 "notice": ""
             },
             {

--- a/package.yml
+++ b/package.yml
@@ -27,7 +27,7 @@ page:
         itemclass: pull-right        
 
 requires:
-  redaxo: '^5.15'
+  redaxo: '^5.17.0'
   yform: '^4.2.1'
   yform/manager: '^4.2.1'
 


### PR DESCRIPTION
Fehlende Klasse `form-control` im YForm-Formular ergänzt.

Umstellung auf rex_loader-API und Redaxo-Mindestversion 5.17.0 (passend zu YForm)
